### PR TITLE
Order History の実装 #6

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,3 +36,13 @@ app.register_blueprint(menu_bp, url_prefix='/menu')
 app.register_blueprint(genre_bp, url_prefix='/genre')
 app.register_blueprint(item_bp, url_prefix='/item')
 app.register_blueprint(order_bp, url_prefix='/order')
+
+
+@app.template_filter()
+def number_format(value):
+    return f'¥{value:,}'
+
+
+@app.template_filter()
+def date_format(value):
+    return value.strftime('%Y/%m/%d')

--- a/app/order/models.py
+++ b/app/order/models.py
@@ -1,6 +1,11 @@
+from collections import namedtuple
 from datetime import datetime
+from itertools import groupby
 
 from app import db
+
+OrderPerItem = namedtuple('OrderPerItem', ('sold_at', 'item', 'quantity', 'amount'))
+OrderPerDay = namedtuple('OrderPerDay', ('sold_at', 'total_amount', 'order_list'))
 
 
 class Order(db.Model):
@@ -19,3 +24,42 @@ class Order(db.Model):
 
     def add_order(self, item_id, quantity):
         pass
+
+
+class OrderHistory:
+    @classmethod
+    def sort_keys(cls, o):
+        return datetime(o.sold_at.year, o.sold_at.month, o.sold_at.day), o.item.name
+
+    @classmethod
+    def calc(cls):
+        order_list = Order.query.all()
+        order_list.sort(key=cls.sort_keys, reverse=True)
+
+        tmp_list = []
+        for key, group in groupby(order_list, key=cls.sort_keys):
+            group = list(group)
+
+            total_quantity = sum(o.quantity for o in group)
+            total_amount = sum(o.price for o in group)
+
+            tmp_list.append(OrderPerItem(
+                sold_at=key[0],
+                item=key[1],
+                quantity=total_quantity,
+                amount=total_amount
+            ))
+
+        result_list = []
+        for key, group in groupby(tmp_list, key=lambda o: o.sold_at):
+            group = list(group)
+
+            total_amount = sum(o.amount for o in group)
+
+            result_list.append(OrderPerDay(
+                sold_at=key,
+                total_amount=total_amount,
+                order_list=group
+            ))
+
+        return result_list

--- a/app/order/views.py
+++ b/app/order/views.py
@@ -1,10 +1,10 @@
 from flask import render_template, flash, redirect, url_for, session, request
 from flask_login import login_required
 
-from app.order.models import Order
 from app.item.models import Item
 from app.order import bp
 from app.order.forms import InputDateForm
+from app.order.models import Order, OrderHistory
 
 
 @bp.route('/index', methods=['GET', 'POST'])
@@ -42,3 +42,15 @@ def setting():
 def register_order():
     for item in Item.get_sale_list():
         Order.add_order(request.form.get(f'val_{item.id}'))
+
+
+@bp.route('/history')
+@login_required
+def history():
+    order_summary_list = OrderHistory.calc()
+
+    return render_template(
+        'order/order_history.html',
+        title='Order History',
+        order_summary_list=order_summary_list
+    )

--- a/app/templates/menu.html
+++ b/app/templates/menu.html
@@ -1,6 +1,7 @@
 {%- extends 'base.html' -%}
 {%- block content -%}
 <p><a href="{{ url_for('order.setting') }}">Order Counter</a></p>
+<p><a href="{{ url_for('order.history') }}">Order History</a></p>
 <p><a href="{{ url_for('item.edit_item') }}">Edit Item</a></p>
 <p><a href="{{ url_for('genre.edit_genre') }}">Edit Genre</a></p>
 {%- endblock -%}

--- a/app/templates/order/order_history.html
+++ b/app/templates/order/order_history.html
@@ -1,0 +1,28 @@
+{%- extends 'base.html' -%}
+{%- block content -%}
+<h1>Order History</h1>
+<table class="table table-striped table-bordered table-hover">
+  <tr>
+    <th>Item</th>
+    <th>Quantity</th>
+    <th>Amount</th>
+  </tr>
+  {%- for order_summary in order_summary_list -%}
+    <tbody>
+      <tr class="table-primary">
+        <td colspan="4">{{ order_summary.sold_at|date_format }}</td>
+      </tr>
+      {%- for order in order_summary.order_list -%}
+      <tr>
+        <td>{{ order.item }}</td>
+        <td>{{ order.quantity }}</td>
+        <td>{{ order.amount|number_format }}</td>
+      </tr>
+      {%- endfor -%}
+      <tr class="table-info">
+        <td colspan="4" class="text-right">Total : {{ order_summary.total_amount|number_format }}</td>
+      </tr>
+    </tbody>
+  {%- endfor -%}
+</table>
+{%- endblock -%}


### PR DESCRIPTION
@arinko-ya 

Order History を実装しました。

デザインは仮でつけてますが、実装内容は以下を反映しています。

- 登録したオーダーを日付別に参照できる画面を作成する
- 金額は * 販売個数したトータルの金額を表示する
- 全合計の金額を表示する（消費税は考慮しない）

「販売個数が 0 の商品は表示しない」は一旦除外しています。(オーダー登録側で処理すれば良さそう？)

イメージは↓です。

![order_history_image](https://user-images.githubusercontent.com/25840007/44403213-cdb60f80-a58e-11e8-93ac-828550b7d41d.png)