### PR TITLE
オーダー登録画面をカテゴリ別のタブ表示にする

### DIFF
--- a/app/order/views.py
+++ b/app/order/views.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+from itertools import groupby
+
 from flask import render_template, flash, redirect, url_for, session, request
 from flask_login import login_required
 
@@ -15,10 +18,21 @@ def order_counter():
         return redirect(url_for('order.setting'))
 
     input_date = session['input_date']
-    item_list = Item.get_sale_list()
+
+    item_list = Item.query.filter_by(
+        is_active=True
+    ).order_by(
+        Item.genre_id,
+        Item.is_high_priority.desc()
+    )
+
+    item_dict = OrderedDict()
+    for key, group in groupby(item_list, key=lambda x: x.genre.name):
+        item_dict[key] = list(group)
+
     return render_template('order/order_counter.html',
                            title='order',
-                           item_list=item_list,
+                           item_dict=item_dict,
                            input_date=input_date)
 
 

--- a/app/templates/order/order_counter.html
+++ b/app/templates/order/order_counter.html
@@ -3,7 +3,47 @@
   <h1>Order Counter</h1>
   <p>{{ input_date }}</p>
   <form action="" method="post">
-    <div class="table">
+    <input type="submit" value="submit">
+    <ul class="nav nav-tabs">
+      {% for key in item_dict.keys() %}
+        <li class="nav-item">
+          <a class="nav-link{% if loop.first %} active{% endif %}"
+             data-toggle="tab" href="#genre-{{ loop.index }}"
+             aria-controls="genre-{{ loop.index }}"
+             aria-selected="{% if loop.first %}true{% else %}false{% endif %}">
+            {{ key }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+    <div class="tab-content">
+      {% for key, item_list in item_dict.items() %}
+        <div class="tab-pane fade{% if loop.first %} show active{% endif %}"
+             id="genre-{{ loop.index }}"
+             aria-labelledby="genre-{{ loop.index }}-tab">
+          {{ table(item_list) }}
+        </div>
+      {% endfor %}
+    </div>
+  </form>
+{%- endblock -%}
+
+{%- block js_area -%}
+  <script language="JavaScript">
+    function plus(chk) {
+      chk.value++;
+    }
+
+    function minus(chk) {
+      if (chk.value != 0) {
+        chk.value--;
+      }
+    }
+  </script>
+{%- endblock -%}
+
+{% macro table(item_list) %}
+  <div class="table">
     {%- for item in item_list -%}
       <div class="tr">
         <span class="td name">{{ item.name }}</span>
@@ -17,20 +57,5 @@
         </span>
       </div>
     {%- endfor -%}
-    </div>
-    <input type="submit" value="submit">
-  </form>
-{%- endblock -%}
-
-{%- block js_area -%}
-<script language="JavaScript">
-  function plus(chk) {
-    chk.value++;
-  }
-  function minus(chk){
-    if (chk.value != 0) {
-      chk.value--;
-    }
-  }
-</script>
-{%- endblock -%}
+  </div>
+{% endmacro %}


### PR DESCRIPTION
@arinko-ya 

## 変更内容

- `order/views.py` から `order_counter.html` に渡す変数を `item_list` から `item_dict` に変更
  - ジャンル名を key にして、アイテム一覧を value にした
- `order_counter.html` で `item_dict` を展開し、タブ表示に必要な情報を追加
- `order_counter.html` 内でテーブル表示を macro にした

## この PR でレビューしてほしいこと

- タブ表示のイメージは仕様通りか

<img width="782" alt="tab_image" src="https://user-images.githubusercontent.com/25840007/45492535-8135ac80-b7a7-11e8-8fe9-dc75b6a6166f.png">